### PR TITLE
feat: custom user fetch interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-Habitica Party Up! is a Go-based application that automates the process of inviting users to a Habitica party. This application fetches users looking for a party every 2 minutes and sends them an invitation automatically.
+Habitica Party Up! is a Go-based application that automates the process of inviting users to a Habitica party. This application fetches users looking for a party based on an interval and sends them an invitation automatically.
 
 ## Features
 
 - Fetches users looking for a Habitica party.
-- Invites users to a Habitica party every 2 minutes.
+- Invites users to a Habitica party on an interval.
 - Configurable API user and API key via environment variables or command-line flags.
 
 ## Prerequisites
@@ -53,6 +53,7 @@ You can configure the application using command-line flags. The following config
 - `api-user`: Your Habitica API user ID.
 - `api-key`: Your Habitica API key.
 - `min-lvl`: Min level of users to invite to party. Default to 0 (invite everybody).
+- `fetch-interval`: Interval for fetching users in seconds. Default is 120 (2 minutes).
 - `language`: Language of users to invite to party. Default is all languages (can be something like "fr" / "en" / "zh", etc.).
 - `only-active`: Only invite active users to party, based on an algorithm. Default is false.
 

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ var apiUser string
 var apiKey string
 
 var minLvl int
+var fetchInterval uint64
 var language string
 var onlyActive bool
 
@@ -58,6 +59,7 @@ func main() {
 	flag.StringVar(&apiUser, "api-user", "", "Habitica API user")
 	flag.StringVar(&apiKey, "api-key", "", "Habitica API key")
 	flag.IntVar(&minLvl, "min-lvl", 0, "Min level of users to invite to party. Default is 0.")
+    flag.Uint64Var(&fetchInterval, "fetch-interval", 120, "Interval for fetching users in seconds. Default is 120.")
 	flag.StringVar(&language, "language", "", "Language of users to invite to party. Default is all languages.")
 	flag.BoolVar(&onlyActive, "only-active", false, "Only invite active users to party. Default is false.")
 	flag.Parse()
@@ -73,7 +75,7 @@ func main() {
 }
 
 func executeCronJob() {
-	gocron.Every(2).Minute().Do(fetchUsersAndInvite)
+	gocron.Every(fetchInterval).Second().Do(fetchUsersAndInvite)
 	<-gocron.Start()
 }
 
@@ -130,7 +132,7 @@ func fetchUsersAndInvite() {
 	if len(usersUuid) != 0 {
 		inviteUsers(habiticaClient, usersUuid)
 	} else {
-		log.Println("No users to invite. Retry in 2 minutes.")
+		log.Printf("No users to invite. Retry in %d seconds.", fetchInterval)
 	}
 }
 
@@ -170,7 +172,7 @@ func inviteUsers(client http.Client, uuids []string) {
 		log.Fatal(readErr)
 	}
 
-	log.Printf("All %d users invited! Relaunch in 2 minutes.", len(uuids))
+	log.Printf("All %d users invited! Relaunch in %d seconds.", len(uuids), fetchInterval)
 }
 
 func isValidUser(user User) bool {


### PR DESCRIPTION
This adds a new feature that allows to set a custom interval for fetching and inviting users. It can be changed using the `--fetch-interval` flag, which is set to 120 seconds (2 minutes) by default.